### PR TITLE
Re-export all crates used in macros to improve macro hygeine

### DIFF
--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -213,6 +213,9 @@ use std::fmt::Display;
 use quicklog_clock::{quanta::QuantaClock, Clock};
 use quicklog_flush::{file_flusher::FileFlusher, Flush};
 
+/// re-export of the lazy_format crate, for use in macros
+pub use lazy_format;
+
 /// contains logging levels and filters
 pub mod level;
 /// contains macros

--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -213,8 +213,9 @@ use std::fmt::Display;
 use quicklog_clock::{quanta::QuantaClock, Clock};
 use quicklog_flush::{file_flusher::FileFlusher, Flush};
 
-/// re-export of the lazy_format crate, for use in macros
+/// re-export of crates, for use in macros
 pub use lazy_format;
+pub use quicklog_flush;
 
 /// contains logging levels and filters
 pub mod level;

--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -215,6 +215,7 @@ use quicklog_flush::{file_flusher::FileFlusher, Flush};
 
 /// re-export of crates, for use in macros
 pub use lazy_format;
+pub use paste;
 pub use quicklog_flush;
 
 /// contains logging levels and filters

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! with_flush {
 #[macro_export]
 macro_rules! with_flush_into_file {
     ($file_path:expr) => {{
-        use quicklog_flush::FileFlusher;
+        use $crate::quicklog_flush::FileFlusher;
         let flusher = FileFlusher::new($file_path);
         $crate::logger().use_flush($crate::make_container!(flusher));
     }};

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -12,8 +12,7 @@ macro_rules! with_flush {
 #[macro_export]
 macro_rules! with_flush_into_file {
     ($file_path:expr) => {{
-        use $crate::quicklog_flush::FileFlusher;
-        let flusher = FileFlusher::new($file_path);
+        let flusher = $crate::quicklog_flush::file_flusher::FileFlusher::new($file_path);
         $crate::logger().use_flush($crate::make_container!(flusher));
     }};
 }

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -117,7 +117,7 @@ macro_rules! try_log {
   // === base case
   // perform the logging by owning arguments
   ($lvl:expr, $static_str:literal @@ {{ $(,)* $($args:expr),* }} @ ($($prefix:tt)*) ($([$($field:tt)*])*)) => {
-    paste::paste! {{
+    $crate::paste::paste! {{
       if $crate::is_level_enabled!($lvl) {
         use $crate::{Log, make_container};
 


### PR DESCRIPTION
When using this crate I noticed that lazy_format, quicklog_flush, and paste also needs to be imported by the end user, or the macros cause a compile error. This PR addresses that, by referring to the re-exported lib in the macros.
Also this is nice because the version of these crates used is always the same as the version depended on by this crate, so there won't be any unexpected conflicts if the end user is separately using a different version.