### PR TITLE
Module path

### DIFF
--- a/quicklog/Cargo.toml
+++ b/quicklog/Cargo.toml
@@ -16,6 +16,7 @@ name = "quicklog"
 path = "src/lib.rs"
 
 [features]
+default = ["module_path"]
 module_path = []
 max_level_off = []
 max_level_error = []

--- a/quicklog/Cargo.toml
+++ b/quicklog/Cargo.toml
@@ -16,7 +16,6 @@ name = "quicklog"
 path = "src/lib.rs"
 
 [features]
-default = ["module_path"]
 module_path = []
 max_level_off = []
 max_level_error = []

--- a/quicklog/Cargo.toml
+++ b/quicklog/Cargo.toml
@@ -16,6 +16,7 @@ name = "quicklog"
 path = "src/lib.rs"
 
 [features]
+module_path = []
 max_level_off = []
 max_level_error = []
 max_level_warn = []

--- a/quicklog/examples/macros.rs
+++ b/quicklog/examples/macros.rs
@@ -1,4 +1,4 @@
-use quicklog::{debug, error, flush, info, trace, warn, with_flush};
+use quicklog::{debug, error, flush, info, init, trace, warn, with_flush};
 use quicklog_flush::stdout_flusher::StdoutFlusher;
 
 #[derive(Clone)]
@@ -13,6 +13,7 @@ impl std::fmt::Display for S {
 }
 
 fn main() {
+    init!();
     with_flush!(StdoutFlusher);
 
     trace!("hello world! {} {} {}", 2, 3, 4);

--- a/quicklog/examples/macros.rs
+++ b/quicklog/examples/macros.rs
@@ -1,4 +1,4 @@
-use quicklog::{debug, error, flush, info, init, trace, warn, with_flush};
+use quicklog::{debug, error, flush_all, info, init, trace, warn, with_flush};
 use quicklog_flush::stdout_flusher::StdoutFlusher;
 
 #[derive(Clone)]
@@ -47,5 +47,5 @@ fn main() {
         s_0, s_1, s_2, s_3, s_4, s_5, s_6, s_7, s_8, s_9, s_10
     );
 
-    flush!();
+    flush_all!();
 }

--- a/quicklog/examples/macros.rs
+++ b/quicklog/examples/macros.rs
@@ -1,4 +1,4 @@
-use quicklog::{debug, error, flush_all, info, init, trace, warn, with_flush};
+use quicklog::{debug, error, flush, info, trace, warn, with_flush};
 use quicklog_flush::stdout_flusher::StdoutFlusher;
 
 #[derive(Clone)]
@@ -13,7 +13,6 @@ impl std::fmt::Display for S {
 }
 
 fn main() {
-    init!();
     with_flush!(StdoutFlusher);
 
     trace!("hello world! {} {} {}", 2, 3, 4);
@@ -47,5 +46,5 @@ fn main() {
         s_0, s_1, s_2, s_3, s_4, s_5, s_6, s_7, s_8, s_9, s_10
     );
 
-    flush_all!();
+    flush!();
 }

--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -214,6 +214,7 @@ use quicklog_clock::{quanta::QuantaClock, Clock};
 use quicklog_flush::{file_flusher::FileFlusher, Flush};
 
 /// re-export of crates, for use in macros
+pub use cfg_if;
 pub use lazy_format;
 pub use paste;
 pub use quicklog_flush;

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -80,8 +80,7 @@ macro_rules! is_level_enabled {
 #[macro_export]
 macro_rules! make_store {
   ($serializable:expr) => {{
-    use cfg_if::cfg_if;
-    cfg_if! {
+    $crate::cfg_if::cfg_if! {
       if #[cfg(debug_assertions)] {
             std::sync::Arc::new($serializable.encode($crate::serialize::get_chunk_as_mut($serializable.buffer_size_required())))
       } else {
@@ -100,7 +99,7 @@ macro_rules! try_log {
     if $crate::is_level_enabled!($lvl) {
       use $crate::{Log, make_container};
 
-      cfg_if::cfg_if! {
+      $crate::cfg_if::cfg_if! {
         if #[cfg(feature = "module_path")] {
           let log_line = $crate::lazy_format::lazy_format!("[{}][{}]\t{}", $lvl, module_path!(), $static_str);
         } else {
@@ -131,7 +130,7 @@ macro_rules! try_log {
         #[allow(unused_parens)]
         let ($([<$($field)*>]),*) = ($(($args).to_owned()),*);
 
-        cfg_if::cfg_if! {
+        $crate::cfg_if::cfg_if! {
           if #[cfg(feature = "module_path")] {
             let log_line = $crate::lazy_format::make_lazy_format!(|f| {
               write!(f, concat!("[{}][{}]\t", $static_str), $lvl, module_path!(), $([<$($field)*>]),*)

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -368,17 +368,6 @@ macro_rules! flush {
     };
 }
 
-/// Allows flushing onto an implementor of [`Flush`], which can be modified with
-/// [`with_flush!`] macro and continues trying to flush until no more lines need flushing.
-///
-/// [`Flush`]: `quicklog_flush::Flush`
-#[macro_export]
-macro_rules! flush_all {
-    () => {
-        while let Ok(()) = $crate::try_flush!() {}
-    };
-}
-
 /// Trace level log
 #[macro_export]
 macro_rules! trace {


### PR DESCRIPTION
Display module_path in log line to help pinpoint where log line came from, just like tokio-tracing. I've made this configurable so as to avoid breaking any existing log line parsing code.