### PR TITLE
flush_all

### DIFF
--- a/quicklog/examples/macros.rs
+++ b/quicklog/examples/macros.rs
@@ -1,4 +1,4 @@
-use quicklog::{debug, error, flush, info, trace, warn, with_flush};
+use quicklog::{debug, error, flush_all, info, init, trace, warn, with_flush};
 use quicklog_flush::stdout_flusher::StdoutFlusher;
 
 #[derive(Clone)]
@@ -13,6 +13,7 @@ impl std::fmt::Display for S {
 }
 
 fn main() {
+    init!();
     with_flush!(StdoutFlusher);
 
     trace!("hello world! {} {} {}", 2, 3, 4);
@@ -46,5 +47,5 @@ fn main() {
         s_0, s_1, s_2, s_3, s_4, s_5, s_6, s_7, s_8, s_9, s_10
     );
 
-    flush!();
+    flush_all!();
 }

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -353,6 +353,17 @@ macro_rules! flush {
     };
 }
 
+/// Allows flushing onto an implementor of [`Flush`], which can be modified with
+/// [`with_flush!`] macro and continues trying to flush until no more lines need flushing.
+///
+/// [`Flush`]: `quicklog_flush::Flush`
+#[macro_export]
+macro_rules! flush_all {
+    () => {
+        while let Ok(()) = $crate::try_flush!() {}
+    };
+}
+
 /// Trace level log
 #[macro_export]
 macro_rules! trace {


### PR DESCRIPTION
Add a small flush_all macro, to flush the entire contents of the buffer. Use this to fix the example.