### PR TITLE
quicklog: allow to change log level filter at run time

### DIFF
--- a/quicklog/Cargo.toml
+++ b/quicklog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicklog"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 description = "fast logging in Rust"
 documentation = "https://docs.rs/quicklog"
@@ -15,27 +15,12 @@ build = "build.rs"
 name = "quicklog"
 path = "src/lib.rs"
 
-[features]
-max_level_off = []
-max_level_error = []
-max_level_warn = []
-max_level_info = []
-max_level_debug = []
-max_level_trace = []
-
-release_max_level_off = []
-release_max_level_error = []
-release_max_level_warn = []
-release_max_level_info = []
-release_max_level_debug = []
-release_max_level_trace = []
-
 [dependencies]
 lazy_format = "2.0.0"
 quicklog-clock = { path = "../quicklog-clock", version = "0.1.3" }
 quicklog-flush = { path = "../quicklog-flush", version = "0.1.3" }
 quanta = "0.10.1"
-once_cell = "1.17.1"
+once_cell = "1.18.0"
 cfg-if = "1.0.0"
 paste = "1.0.9"
 heapless = "0.7.16"

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -60,15 +60,12 @@ macro_rules! log {
   };
 }
 
-/// Checks if the current level we are trying to log is enabled by checking
-/// static [`MAX_LOG_LEVEL`] which is evaluated at compile time
-///
-/// [`MAX_LOG_LEVEL`]: crate::level::MAX_LOG_LEVEL
+/// Checks if the current level we are trying to log is enabled
 #[doc(hidden)]
 #[macro_export]
 macro_rules! is_level_enabled {
     ($level:expr) => {
-        $level as usize >= $crate::level::MAX_LOG_LEVEL as usize
+        $level as usize >= $crate::level::max_level() as usize
     };
 }
 


### PR DESCRIPTION
Allows run-time modification of the global log level filter through `set_max_level`.