### PR TITLE
quicklog: LogRecord representation

### DIFF
--- a/quicklog/Cargo.toml
+++ b/quicklog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicklog"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 description = "fast logging in Rust"
 documentation = "https://docs.rs/quicklog"

--- a/quicklog/Cargo.toml
+++ b/quicklog/Cargo.toml
@@ -24,6 +24,7 @@ once_cell = "1.18.0"
 cfg-if = "1.0.0"
 paste = "1.0.9"
 heapless = "0.7.16"
+chrono = "0.4.24"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/quicklog/examples/macros.rs
+++ b/quicklog/examples/macros.rs
@@ -1,4 +1,7 @@
-use quicklog::{debug, error, flush_all, info, init, trace, warn, with_flush};
+use quicklog::{
+    debug, error, flush_all, info, init, trace, warn, with_flush, with_formatter, LogRecord,
+    PatternFormatter,
+};
 use quicklog_flush::stdout_flusher::StdoutFlusher;
 
 #[derive(Clone)]
@@ -12,9 +15,25 @@ impl std::fmt::Display for S {
     }
 }
 
+struct CustomFormatter;
+
+impl PatternFormatter for CustomFormatter {
+    fn custom_format(
+        &mut self,
+        time: chrono::DateTime<chrono::Utc>,
+        log_record: LogRecord,
+    ) -> String {
+        format!(
+            "[{:?}][{}][{}][{}]{}\n",
+            time, log_record.file, log_record.line, log_record.level, log_record.log_line,
+        )
+    }
+}
+
 fn main() {
     init!();
     with_flush!(StdoutFlusher);
+    with_formatter!(CustomFormatter);
 
     trace!("hello world! {} {} {}", 2, 3, 4);
     trace!("hello, world");

--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -205,11 +205,15 @@
 //! [`FileFlusher`]: quicklog_flush::file_flusher::FileFlusher
 
 use heapless::spsc::Queue;
+use level::Level;
 use once_cell::unsync::{Lazy, OnceCell};
 use quanta::Instant;
 use serialize::buffer::{Buffer, BUFFER};
 use std::fmt::Display;
 
+pub use std::{file, line, module_path};
+
+use chrono::{DateTime, Utc};
 use quicklog_clock::{quanta::QuantaClock, Clock};
 use quicklog_flush::{file_flusher::FileFlusher, Flush};
 
@@ -231,20 +235,20 @@ pub mod constants;
 
 /// Internal API
 ///
-/// Intermediate log item being stored into logging queue
+/// timed log item being stored into logging queue
 #[doc(hidden)]
-pub type Intermediate = (Instant, Box<dyn Display>);
+pub type TimedLogRecord = (Instant, LogRecord);
 
 /// Logger initialized to Quicklog
 #[doc(hidden)]
 static mut LOGGER: Lazy<Quicklog> = Lazy::new(Quicklog::default);
 
 /// Producer side of queue
-pub type Sender = heapless::spsc::Producer<'static, Intermediate, MAX_LOGGER_CAPACITY>;
+pub type Sender = heapless::spsc::Producer<'static, TimedLogRecord, MAX_LOGGER_CAPACITY>;
 /// Result from pushing onto queue
-pub type SendResult = Result<(), Intermediate>;
+pub type SendResult = Result<(), TimedLogRecord>;
 /// Consumer side of queue
-pub type Receiver = heapless::spsc::Consumer<'static, Intermediate, MAX_LOGGER_CAPACITY>;
+pub type Receiver = heapless::spsc::Consumer<'static, TimedLogRecord, MAX_LOGGER_CAPACITY>;
 /// Result from trying to pop from logging queue
 pub type RecvResult = Result<(), FlushError>;
 
@@ -256,10 +260,10 @@ static mut RECEIVER: OnceCell<Receiver> = OnceCell::new();
 /// Log is the base trait that Quicklog will implement.
 /// Flushing and formatting is deferred while logging.
 pub trait Log {
-    /// Dequeues a single line from logging queue and passes it to Flusher
+    /// Dequeues a single log record from logging queue and passes it to Flusher
     fn flush_one(&mut self) -> RecvResult;
-    /// Enqueues a single line onto logging queue
-    fn log(&self, display: Box<dyn Display>) -> SendResult;
+    /// Enqueues a single log record onto logging queue
+    fn log(&self, record: LogRecord) -> SendResult;
 }
 
 /// Errors that can be presented when flushing
@@ -277,10 +281,42 @@ pub fn logger() -> &'static mut Quicklog {
     unsafe { &mut LOGGER }
 }
 
+pub struct LogRecord {
+    /// Level
+    pub level: Level,
+    /// Module path
+    pub module_path: &'static str,
+    /// File
+    pub file: &'static str,
+    /// Line
+    pub line: u32,
+    /// Log line captured by using LazyFormat which implements Display trait.
+    pub log_line: Box<dyn Display>,
+}
+
+pub trait PatternFormatter {
+    fn custom_format(&mut self, time: DateTime<Utc>, log_record: LogRecord) -> String;
+}
+
+pub struct QuickLogFormatter;
+
+impl QuickLogFormatter {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl PatternFormatter for QuickLogFormatter {
+    fn custom_format(&mut self, time: DateTime<Utc>, object: LogRecord) -> String {
+        format!("[{:?}]{}\n", time, object.log_line)
+    }
+}
+
 /// Quicklog implements the Log trait, to provide logging
 pub struct Quicklog {
     flusher: Box<dyn Flush>,
     clock: Box<dyn Clock>,
+    formatter: Box<dyn PatternFormatter>,
 }
 
 impl Quicklog {
@@ -288,6 +324,10 @@ impl Quicklog {
     #[doc(hidden)]
     pub fn use_flush(&mut self, flush: Box<dyn Flush>) {
         self.flusher = flush
+    }
+
+    pub fn use_formatter(&mut self, formatter: Box<dyn PatternFormatter>) {
+        self.formatter = formatter
     }
 
     /// Sets which flusher to be used, used in [`with_clock!`]
@@ -312,7 +352,7 @@ impl Quicklog {
 
     /// Initializes channel for main logging queue
     fn init_channel() {
-        static mut QUEUE: Queue<Intermediate, MAX_LOGGER_CAPACITY> = Queue::new();
+        static mut QUEUE: Queue<TimedLogRecord, MAX_LOGGER_CAPACITY> = Queue::new();
         let (sender, receiver): (Sender, Receiver) = unsafe { QUEUE.split() };
         unsafe {
             SENDER.set(sender).ok();
@@ -326,17 +366,18 @@ impl Default for Quicklog {
         Quicklog {
             flusher: Box::new(FileFlusher::new("logs/quicklog.log")),
             clock: Box::new(QuantaClock::new()),
+            formatter: Box::new(QuickLogFormatter::new()),
         }
     }
 }
 
 impl Log for Quicklog {
-    fn log(&self, display: Box<dyn Display>) -> SendResult {
+    fn log(&self, record: LogRecord) -> SendResult {
         match unsafe {
             SENDER
                 .get_mut()
                 .expect("Sender is not initialized, `Quicklog::init()` needs to be called at the entry point of your application")
-                .enqueue((self.clock.get_instant(), display))
+                .enqueue((self.clock.get_instant(), record))
         } {
             Ok(_) => Ok(()),
             Err(err) => Err(err),
@@ -350,13 +391,12 @@ impl Log for Quicklog {
                     .expect("RECEIVER is not initialized, `Quicklog::init()` needs to be called at the entry point of your application")
                     .dequeue()
         } {
-            Some((time_logged, disp)) => {
-                let log_line = format!(
-                    "[{:?}]{}\n",
+            Some((time_logged, record)) => {
+                let log_line = self.formatter.custom_format(
                     self.clock
                         .compute_system_time_from_instant(time_logged)
                         .expect("Unable to get time from instant"),
-                    disp
+                    record,
                 );
                 self.flusher.flush_one(log_line);
                 Ok(())
@@ -370,13 +410,31 @@ impl Log for Quicklog {
 mod tests {
     use std::{str::from_utf8, sync::Mutex};
 
+    use chrono::{DateTime, Utc};
     use quicklog_flush::Flush;
 
     use crate::{
         debug, error, flush, info,
         serialize::{Serialize, Store},
-        trace, warn,
+        trace, warn, LogRecord, PatternFormatter,
     };
+
+    pub struct TestFormatter;
+
+    impl TestFormatter {
+        fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl PatternFormatter for TestFormatter {
+        fn custom_format(&mut self, time: DateTime<Utc>, log_record: LogRecord) -> String {
+            format!(
+                "[{:?}][{}]\t{}\n",
+                time, log_record.level, log_record.log_line
+            )
+        }
+    }
 
     struct VecFlusher {
         pub vec: &'static mut Vec<String>,
@@ -432,6 +490,7 @@ mod tests {
             static mut VEC: Vec<String> = Vec::new();
             let vec_flusher = unsafe { VecFlusher::new(&mut VEC) };
             crate::logger().use_flush(Box::new(vec_flusher));
+            crate::logger().use_formatter(Box::new(TestFormatter::new()))
         };
     }
 

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -8,6 +8,16 @@ macro_rules! with_flush {
     }};
 }
 
+/// Used to amend which `PatternFormatter` is currently attached to `Quicklog`
+/// An implementation can be passed in at runtime as long as it
+/// adheres to the `PatternFormatter` trait in `quicklog-formatter`
+#[macro_export]
+macro_rules! with_formatter {
+    ($formatter:expr) => {{
+        $crate::logger().use_formatter($crate::make_container!($formatter))
+    }};
+}
+
 /// Flushes log lines into the file path specified
 #[macro_export]
 macro_rules! with_flush_into_file {
@@ -97,9 +107,15 @@ macro_rules! try_log {
     if $crate::is_level_enabled!($lvl) {
       use $crate::{Log, make_container};
 
-      let log_line = $crate::lazy_format::lazy_format!("[{}]\t{}", $lvl, $static_str);
+      let log_record = $crate::LogRecord {
+        level: $lvl,
+        module_path:$crate::module_path!(),
+        file: $crate::file!(),
+        line: $crate::line!(),
+        log_line: make_container!($crate::lazy_format::lazy_format!("{}", $static_str)),
+      };
 
-      $crate::logger().log(make_container!(log_line))
+      $crate::logger().log(log_record)
     } else {
       Ok(())
     }
@@ -122,11 +138,17 @@ macro_rules! try_log {
         #[allow(unused_parens)]
         let ($([<$($field)*>]),*) = ($(($args).to_owned()),*);
 
-        let log_line = $crate::lazy_format::make_lazy_format!(|f| {
-          write!(f, concat!("[{}]\t", $static_str), $lvl, $([<$($field)*>]),*)
-        });
+        let log_record = $crate::LogRecord {
+            level: $lvl,
+            module_path:$crate::module_path!(),
+            file: $crate::file!(),
+            line: $crate::line!(),
+            log_line: make_container!($crate::lazy_format::make_lazy_format!(|f| {
+              write!(f,  $static_str,  $([<$($field)*>]),*)
+            })),
+          };
 
-        $crate::logger().log(make_container!(log_line))
+        $crate::logger().log(log_record)
       } else {
         Ok(())
       }


### PR DESCRIPTION
- Changes the underlying representation logged to the queue to a new `LogRecord` type.
- Introduces a `PatternFormatter` interface that makes use of this new type.