### PR TITLE
macros: fix `var = %x` expressions not matching

### DIFF
--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -806,6 +806,10 @@ mod tests {
             info!("single eager display: {}", %s2),
             format!("single eager display: {}", s2)
         );
+        assert_message_equal!(
+            info!("single eager display with prefix: {}", a = %s2),
+            format!("single eager display with prefix: a={}", s2)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes matching of macros with a *single* `var = %x` expression.