### PR TITLE
fix(quicklog): migrate to std OnceCell

### DIFF
--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -206,9 +206,10 @@
 
 use heapless::spsc::Queue;
 use level::Level;
-use once_cell::unsync::{Lazy, OnceCell};
+use once_cell::unsync::Lazy;
 use quanta::Instant;
 use serialize::buffer::ByteBuffer;
+use std::cell::OnceCell;
 use std::fmt::Display;
 
 pub use std::{file, line, module_path};


### PR DESCRIPTION
Bumps MSRV to 1.70 (in preparation for 0.2.0).