### PR TITLE
quicklog(serialize): modify `encode` signature

### DIFF
--- a/quicklog/benches/logger_benchmark.rs
+++ b/quicklog/benches/logger_benchmark.rs
@@ -25,8 +25,8 @@ struct Nested {
 }
 
 impl Serialize for BigStruct {
-    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> Store<'buf> {
-        let (chunk, _) = write_buf.split_at_mut(self.buffer_size_required());
+    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> (Store<'buf>, &'buf mut [u8]) {
+        let (chunk, rest) = write_buf.split_at_mut(self.buffer_size_required());
 
         let elm_size = std::mem::size_of::<i32>();
         let (vec_chunk, str_chunk) = chunk.split_at_mut(self.vec.len() * elm_size);
@@ -38,7 +38,7 @@ impl Serialize for BigStruct {
 
         _ = self.some.encode(str_chunk);
 
-        Store::new(Self::decode, chunk)
+        (Store::new(Self::decode, chunk), rest)
     }
 
     fn decode(buf: &[u8]) -> (String, &[u8]) {

--- a/quicklog/examples/macros.rs
+++ b/quicklog/examples/macros.rs
@@ -17,7 +17,7 @@ impl std::fmt::Display for S {
 }
 
 impl Serialize for S {
-    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> Store<'buf> {
+    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> (Store<'buf>, &'buf mut [u8]) {
         self.i.encode(write_buf)
     }
 

--- a/quicklog/src/lib.rs
+++ b/quicklog/src/lib.rs
@@ -88,7 +88,7 @@
 //! }
 //!
 //! impl Serialize for SomeStruct {
-//!    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> Store<'buf> { /* some impl */ }
+//!    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> (Store<'buf>, &'buf mut[u8]) { /* some impl */ }
 //!    fn decode(read_buf: &[u8]) -> (String, &[u8]) { /* some impl */ }
 //!    fn buffer_size_required(&self) -> usize { /* some impl */ }
 //! }

--- a/quicklog/src/macros.rs
+++ b/quicklog/src/macros.rs
@@ -76,8 +76,10 @@ macro_rules! is_level_enabled {
 macro_rules! make_store {
     ($serializable:expr) => {{
         use $crate::serialize::Serialize;
-        $serializable
-            .encode($crate::logger().get_chunk_as_mut($serializable.buffer_size_required()))
+        let (store, _) = $serializable
+            .encode($crate::logger().get_chunk_as_mut($serializable.buffer_size_required()));
+
+        store
     }};
 }
 

--- a/quicklog/tests/common/mod.rs
+++ b/quicklog/tests/common/mod.rs
@@ -105,7 +105,7 @@ pub(crate) struct SerializeStruct {
 }
 
 impl Serialize for SerializeStruct {
-    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> Store<'buf> {
+    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> (Store<'buf>, &'buf mut [u8]) {
         self.symbol.as_str().encode(write_buf)
     }
 
@@ -125,8 +125,8 @@ pub(crate) struct BigStruct {
 }
 
 impl Serialize for BigStruct {
-    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> Store<'buf> {
-        let (chunk, _) = write_buf.split_at_mut(self.buffer_size_required());
+    fn encode<'buf>(&self, write_buf: &'buf mut [u8]) -> (Store<'buf>, &'buf mut [u8]) {
+        let (chunk, rest) = write_buf.split_at_mut(self.buffer_size_required());
 
         let elm_size = std::mem::size_of::<i32>();
         let (vec_chunk, str_chunk) = chunk.split_at_mut(self.vec.len() * elm_size);
@@ -138,7 +138,7 @@ impl Serialize for BigStruct {
 
         _ = self.some.encode(str_chunk);
 
-        Store::new(Self::decode, chunk)
+        (Store::new(Self::decode, chunk), rest)
     }
 
     fn decode(buf: &[u8]) -> (String, &[u8]) {

--- a/quicklog/tests/failures/struct_missing_display.stderr
+++ b/quicklog/tests/failures/struct_missing_display.stderr
@@ -41,7 +41,7 @@ error[E0599]: no method named `encode` found for struct `Something` in the curre
 help: one of the expressions' fields has a method of the same name
   --> src/macros.rs
    |
-   |             .some_str.encode($crate::logger().get_chunk_as_mut($serializable.buffer_size_required()))
+   |             .some_str.encode($crate::logger().get_chunk_as_mut($serializable.buffer_size_required()));
    |              +++++++++
 
 error[E0599]: no method named `buffer_size_required` found for struct `Something` in the current scope
@@ -62,5 +62,5 @@ error[E0599]: no method named `buffer_size_required` found for struct `Something
 help: one of the expressions' fields has a method of the same name
   --> src/macros.rs
    |
-   |             .encode($crate::logger().get_chunk_as_mut($serializable.some_str.buffer_size_required()))
+   |             .encode($crate::logger().get_chunk_as_mut($serializable.some_str.buffer_size_required()));
    |                                                                     +++++++++


### PR DESCRIPTION
Modifies `encode` to return the remainder of the passed-in write buffer by convention.